### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/abyssal512/5752da90-1d92-4bc4-affc-9f915c72dd99/6116e7f2-5e4a-438b-b62a-5c91b324fd49/_apis/work/boardbadge/b68e9b92-384a-4282-9484-284b2b2b198b)](https://dev.azure.com/abyssal512/5752da90-1d92-4bc4-affc-9f915c72dd99/_boards/board/t/6116e7f2-5e4a-438b-b62a-5c91b324fd49/Microsoft.RequirementCategory)
 # Abyssal's Spotify Wrapper
 A Spotify API wrapper for .NET Standard 2.0.  
   


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/abyssal512/5752da90-1d92-4bc4-affc-9f915c72dd99/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.